### PR TITLE
Move from nut2 to PyNUTClient

### DIFF
--- a/octoprint_ups/__init__.py
+++ b/octoprint_ups/__init__.py
@@ -10,7 +10,7 @@ from octoprint.events import Events
 import time
 import threading
 from flask import make_response, jsonify
-import PyNUTClient.PyNUT as nut2
+from PyNUTClient import PyNUT
 
 try:
     from octoprint.access.permissions import Permissions
@@ -102,7 +102,7 @@ class UPS(octoprint.plugin.StartupPlugin,
         if not auth or password == "":
             password = None
 
-        return nut2.PyNUTClient(host=host, port=port, login=username, password=password)
+        return PyNUT.PyNUTClient(host=host, port=port, login=username, password=password)
 
 
     def _loop(self):
@@ -131,7 +131,7 @@ class UPS(octoprint.plugin.StartupPlugin,
 
             try:
                 vars = self.ups.GetUPSVars(ups=self.config['ups'])
-            except nut2.PyNUTError as e:
+            except PyNUT.PyNUTError as e:
                 msg = str(e)
                 if msg == "ERR DATA-STALE":
                     # Basically seems like an unable to fetch / refresh data error.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 OctoPrint
-nut2
+PyNUTClient


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Move from old nut2 Python lib to more recent, still supported and first party PyNUTClient Python lib. 

#### How was it tested? How can it be tested by the reviewer?

I don't get any errors in Octoprint's log on my setup (Raspberry Pi OS Bookworm + OctoPrint 1.10.1 + CyberPower UPS over USB) although I do only have the one UPS handy to test with; that said, this PR should cover what the old library did 1:1.

#### What are the relevant tickets if any?

#16 

